### PR TITLE
Make the color attribute optional

### DIFF
--- a/lib/src/build_tile.dart
+++ b/lib/src/build_tile.dart
@@ -24,7 +24,7 @@ class BuildTile extends StatefulWidget {
   final bool isCard;
   final BoxShadow shadow;
   final double borderRadius;
-  final Color color;
+  final Color? color;
   final HitTestBehavior behavior;
   final BackgroundBuilder backgroundBuilder;
   final double swipeThreshold;
@@ -40,9 +40,9 @@ class BuildTile extends StatefulWidget {
 
   const BuildTile({
     Key? key,
+    this.color,
     required this.child,
     required this.backgroundBuilder,
-    required this.color,
     required this.swipeThreshold,
     required this.confirmSwipe,
     required this.borderRadius,
@@ -375,7 +375,7 @@ class _BuildTileState extends State<BuildTile>
     final bool isCard = widget.isCard;
     final BoxShadow shadow = widget.shadow;
     final double borderRadius = widget.borderRadius;
-    final Color color = widget.color;
+    final Color? color = widget.color;
     final bool isEelevated = widget.isEelevated;
 
     super.build(context); // See AutomaticKeepAliveClientMixin.

--- a/lib/src/card_tile.dart
+++ b/lib/src/card_tile.dart
@@ -11,10 +11,11 @@ class CardTile extends StatelessWidget {
   final EdgeInsetsGeometry padding;
   final BoxShadow shadow;
   final double borderRadius;
-  final Color color;
+  final Color? color;
 
   const CardTile({
     Key? key,
+    this.color,
     required this.moveAnimation,
     required this.controller,
     required this.child,
@@ -23,7 +24,6 @@ class CardTile extends StatelessWidget {
     required this.padding,
     required this.shadow,
     required this.borderRadius,
-    required this.color,
   }) : super(key: key);
 
   @override

--- a/lib/src/normal_tile.dart
+++ b/lib/src/normal_tile.dart
@@ -9,11 +9,12 @@ class NormalTile extends StatelessWidget {
   final Widget background;
   final EdgeInsetsGeometry padding;
   final double borderRadius;
-  final Color color;
+  final Color? color;
   final bool isEelevated;
 
   const NormalTile({
     Key? key,
+    this.color,
     required this.moveAnimation,
     required this.controller,
     required this.child,
@@ -21,7 +22,6 @@ class NormalTile extends StatelessWidget {
     required this.direction,
     required this.padding,
     required this.borderRadius,
-    required this.color,
     required this.isEelevated,
   }) : super(key: key);
 

--- a/lib/swipeable_tile.dart
+++ b/lib/swipeable_tile.dart
@@ -11,7 +11,7 @@ class SwipeableTile extends StatelessWidget {
   final bool isCard;
   final BoxShadow shadow;
   final double borderRadius;
-  final Color color;
+  final Color? color;
 
   /// How to behave during hit tests.
   ///
@@ -65,9 +65,9 @@ class SwipeableTile extends StatelessWidget {
   const SwipeableTile({
     required Key key,
     required this.child,
-    required this.backgroundBuilder,
-    required this.color,
+    required this.backgroundBuilder, 
     required this.onSwiped,
+    this.color,
     this.swipeThreshold = 0.4,
     this.confirmSwipe,
     this.borderRadius = 8.0,
@@ -101,8 +101,8 @@ class SwipeableTile extends StatelessWidget {
     required this.horizontalPadding,
     required this.verticalPadding,
     required this.shadow,
-    required this.color,
     required this.onSwiped,
+    this.color,
     this.borderRadius = 16,
     this.swipeThreshold = 0.4,
     this.confirmSwipe,
@@ -131,8 +131,8 @@ class SwipeableTile extends StatelessWidget {
     required Key key,
     required this.child,
     required this.backgroundBuilder,
-    required this.color,
     required this.onSwiped,
+    this.color,
     this.swipeThreshold = 0.4,
     this.borderRadius = 8.0,
     this.direction = SwipeDirection.endToStart,
@@ -167,8 +167,8 @@ class SwipeableTile extends StatelessWidget {
     required this.horizontalPadding,
     required this.verticalPadding,
     required this.shadow,
-    required this.color,
     required this.onSwiped,
+    this.color,
     this.borderRadius = 16,
     this.swipeThreshold = 0.4,
     this.direction = SwipeDirection.endToStart,


### PR DESCRIPTION
This PR makes the color attribute of the tiles optional to allow use cases where content may
be below the tile that cannot be represented by a single color, e.g. a background image.

Since the attribute was required until this PR, code should not break by this change.